### PR TITLE
Add fail-fast & update tests

### DIFF
--- a/body_test.go
+++ b/body_test.go
@@ -2,18 +2,34 @@ package vhttp_test
 
 import "testing"
 
-func TestBodyIs(t *testing.T) {}
+func TestBodyIs(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestBodyIsString(t *testing.T) {}
+func TestBodyIsString(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestBodyIsValidJSON(t *testing.T) {}
+func TestBodyIsValidJSON(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestBodyLengthIs(t *testing.T) {}
+func TestBodyLengthIs(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestBodyIsNil(t *testing.T) {}
+func TestBodyIsNil(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestBodyDetectedTypeIs(t *testing.T) {}
+func TestBodyDetectedTypeIs(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestBodyJSONUnmarshalsAs(t *testing.T) {}
+func TestBodyJSONUnmarshalsAs(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestBodyXMLUnmarshalsAs(t *testing.T) {}
+func TestBodyXMLUnmarshalsAs(t *testing.T) {
+	t.Errorf("not implemented")
+}

--- a/header.go
+++ b/header.go
@@ -42,7 +42,7 @@ func HasHeader(h string) HeaderValidator {
 
 // HasHeaderContentType creates a request validator that checks that the
 // "Content-Type" header is present in the request object.
-func HasHeaderContentType(ct string) HeaderValidator {
+func HasHeaderContentType() HeaderValidator {
 	return HasHeader("Content-Type")
 }
 

--- a/header_test.go
+++ b/header_test.go
@@ -1,27 +1,259 @@
 package vhttp_test
 
-import "testing"
+import (
+	"net/http"
+	"testing"
 
-func TestHasHeader(t *testing.T) {}
+	"github.com/a-poor/vhttp"
+)
 
-func TestHasHeaderContentType(t *testing.T) {}
+func TestHasHeader(t *testing.T) {
+	cases := []struct {
+		name    string      // Case name
+		key     string      // Header to search for
+		headers http.Header // Request's headers
+		isErr   bool        // Should an error be returned
+	}{
+		{
+			name: "success-and-normalize-key",
+			key:  "content-type",
+			headers: http.Header{
+				vhttp.HeaderContentType: []string{"application/json"},
+			},
+			isErr: false,
+		},
+		{
+			name:    "missing-error",
+			key:     "content-type",
+			headers: http.Header{},
+			isErr:   true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Create the validator function
+			vf := vhttp.HasHeader(c.key)
 
-func TestHasHeaderAccept(t *testing.T) {}
+			// Validate and check for an error
+			err := vf(c.headers)
 
-func TestHasHeaderAuthorization(t *testing.T) {}
+			// Unexpected error?
+			if err != nil && !c.isErr {
+				t.Errorf("unexpected error returned for error %q: %s", c.key, err)
+				return
+			}
 
-func TestHeaderIs(t *testing.T) {}
+			// Unexpected success?
+			if err == nil && c.isErr {
+				t.Errorf("expected an error to be returned searching for %q", c.key)
+				return
+			}
 
-func TestHeaderAuthorizationIs(t *testing.T) {}
+			// Expected error?
+			if err != nil && c.isErr {
+				t.Log("successfully returned an error!")
+				return
+			}
 
-func TestHeaderContentTypeIs(t *testing.T) {}
+			// Expected success?
+			if err == nil && !c.isErr {
+				t.Log("successfully returned no error!")
+				return
+			}
+		})
+	}
+}
 
-func TestHeaderContentTypeJSON(t *testing.T) {}
+func TestHasHeaderContentType(t *testing.T) {
+	cases := []struct {
+		name    string      // Case name
+		headers http.Header // Request's headers
+		isErr   bool        // Should an error be returned
+	}{
+		{
+			name: "success-and-normalize-key",
+			headers: http.Header{
+				vhttp.HeaderContentType: []string{"application/json"},
+			},
+			isErr: false,
+		},
+		{
+			name:    "missing-error",
+			headers: http.Header{},
+			isErr:   true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Create the validator function
+			vf := vhttp.HasHeaderContentType()
 
-func TestHeaderContentTypeXML(t *testing.T) {}
+			// Validate and check for an error
+			err := vf(c.headers)
 
-func TestHeaderMatches(t *testing.T) {}
+			// Unexpected error?
+			if err != nil && !c.isErr {
+				t.Errorf("unexpected error returned for error %q: %s", "Content-Type", err)
+				return
+			}
 
-func TestHeaderAuthorizationMatchesBasic(t *testing.T) {}
+			// Unexpected success?
+			if err == nil && c.isErr {
+				t.Errorf("expected an error to be returned searching for %q", "Content-Type")
+				return
+			}
 
-func TestHeaderAuthorizationMatchesBearer(t *testing.T) {}
+			// Expected error?
+			if err != nil && c.isErr {
+				t.Log("successfully returned an error!")
+				return
+			}
+
+			// Expected success?
+			if err == nil && !c.isErr {
+				t.Log("successfully returned no error!")
+				return
+			}
+		})
+	}
+}
+
+func TestHasHeaderAccept(t *testing.T) {
+	cases := []struct {
+		name    string      // Case name
+		headers http.Header // Request's headers
+		isErr   bool        // Should an error be returned
+	}{
+		{
+			name: "success-and-normalize-key",
+			headers: http.Header{
+				vhttp.HeaderAccept: []string{"application/json"},
+			},
+			isErr: false,
+		},
+		{
+			name:    "missing-error",
+			headers: http.Header{},
+			isErr:   true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Create the validator function
+			vf := vhttp.HasHeaderAccept()
+
+			// Validate and check for an error
+			err := vf(c.headers)
+
+			// Unexpected error?
+			if err != nil && !c.isErr {
+				t.Errorf("unexpected error returned for error %q: %s", "Accept", err)
+				return
+			}
+
+			// Unexpected success?
+			if err == nil && c.isErr {
+				t.Errorf("expected an error to be returned searching for %q", "Accept")
+				return
+			}
+
+			// Expected error?
+			if err != nil && c.isErr {
+				t.Log("successfully returned an error!")
+				return
+			}
+
+			// Expected success?
+			if err == nil && !c.isErr {
+				t.Log("successfully returned no error!")
+				return
+			}
+		})
+	}
+}
+
+func TestHasHeaderAuthorization(t *testing.T) {
+	cases := []struct {
+		name    string      // Case name
+		headers http.Header // Request's headers
+		isErr   bool        // Should an error be returned
+	}{
+		{
+			name: "success-and-normalize-key",
+			headers: http.Header{
+				vhttp.HeaderAuthorization: []string{"Bearer abc123"},
+			},
+			isErr: false,
+		},
+		{
+			name:    "missing-error",
+			headers: http.Header{},
+			isErr:   true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Create the validator function
+			vf := vhttp.HasHeaderAuthorization()
+
+			// Validate and check for an error
+			err := vf(c.headers)
+
+			// Unexpected error?
+			if err != nil && !c.isErr {
+				t.Errorf("unexpected error returned for error %q: %s", "Authorization", err)
+				return
+			}
+
+			// Unexpected success?
+			if err == nil && c.isErr {
+				t.Errorf("expected an error to be returned searching for %q", "Authorization")
+				return
+			}
+
+			// Expected error?
+			if err != nil && c.isErr {
+				t.Log("successfully returned an error!")
+				return
+			}
+
+			// Expected success?
+			if err == nil && !c.isErr {
+				t.Log("successfully returned no error!")
+				return
+			}
+		})
+	}
+}
+
+func TestHeaderIs(t *testing.T) {
+	t.Errorf("not implemented")
+}
+
+func TestHeaderAuthorizationIs(t *testing.T) {
+	t.Errorf("not implemented")
+}
+
+func TestHeaderContentTypeIs(t *testing.T) {
+	t.Errorf("not implemented")
+}
+
+func TestHeaderContentTypeJSON(t *testing.T) {
+	t.Errorf("not implemented")
+}
+
+func TestHeaderContentTypeXML(t *testing.T) {
+	t.Errorf("not implemented")
+}
+
+func TestHeaderMatches(t *testing.T) {
+	t.Errorf("not implemented")
+}
+
+func TestHeaderAuthorizationMatchesBasic(t *testing.T) {
+	t.Errorf("not implemented")
+}
+
+func TestHeaderAuthorizationMatchesBearer(t *testing.T) {
+	t.Errorf("not implemented")
+}

--- a/internal_error_test.go
+++ b/internal_error_test.go
@@ -2,4 +2,6 @@ package vhttp_test
 
 import "testing"
 
-func TestInternalError(t *testing.T) {}
+func TestInternalError(t *testing.T) {
+	t.Errorf("not implemented")
+}

--- a/proto_test.go
+++ b/proto_test.go
@@ -1,1 +1,7 @@
 package vhttp_test
+
+import "testing"
+
+func TestProtoValidator(t *testing.T) {
+	t.Errorf("not implemented")
+}

--- a/status_test.go
+++ b/status_test.go
@@ -2,24 +2,46 @@ package vhttp_test
 
 import "testing"
 
-func TestStatusIs(t *testing.T) {}
+func TestStatusIs(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestStatusIsNot(t *testing.T) {}
+func TestStatusIsNot(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestStatusIsOK(t *testing.T) {}
+func TestStatusIsOK(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestStatusInRange(t *testing.T) {}
+func TestStatusInRange(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestStatusNotInRange(t *testing.T) {}
+func TestStatusNotInRange(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestStatusIs1XX(t *testing.T) {}
+func TestStatusIs1XX(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestStatusIs2XX(t *testing.T) {}
+func TestStatusIs2XX(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestStatusIs3XX(t *testing.T) {}
+func TestStatusIs3XX(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestStatusIs4XX(t *testing.T) {}
+func TestStatusIs4XX(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestStatusIs5XX(t *testing.T) {}
+func TestStatusIs5XX(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestStatusNotError(t *testing.T) {}
+func TestStatusNotError(t *testing.T) {
+	t.Errorf("not implemented")
+}

--- a/tls_test.go
+++ b/tls_test.go
@@ -2,8 +2,14 @@ package vhttp_test
 
 import "testing"
 
-func TestTLSIsNil(t *testing.T) {}
+func TestTLSIsNil(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestTLSIsNotNil(t *testing.T) {}
+func TestTLSIsNotNil(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestTLSVersionIs(t *testing.T) {}
+func TestTLSVersionIs(t *testing.T) {
+	t.Errorf("not implemented")
+}

--- a/url_test.go
+++ b/url_test.go
@@ -184,12 +184,22 @@ func TestURLUserinfoIs(t *testing.T) {
 	})
 }
 
-func TestURLHostIs(t *testing.T) {}
+func TestURLHostIs(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestURLPathGlob(t *testing.T) {}
+func TestURLPathGlob(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestURLQueryHas(t *testing.T) {}
+func TestURLQueryHas(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestURLQueryIs(t *testing.T) {}
+func TestURLQueryIs(t *testing.T) {
+	t.Errorf("not implemented")
+}
 
-func TestURLQueryValueValidator(tt *testing.T) {}
+func TestURLQueryValueValidator(t *testing.T) {
+	t.Errorf("not implemented")
+}

--- a/vhttp.go
+++ b/vhttp.go
@@ -78,6 +78,14 @@ func (v ResponseFunc) ValidateResponse(res *http.Response) error {
 }
 
 // ValidateRequest validates the request against the given validators.
+//
+//	err := vhttp.ValidateRequest(req,
+//		vhttp.MethodIsGet(),                      // Method == GET
+//		vhttp.BodyIsValidJSON(),                  // Body can be parsed as JSON
+//		vhttp.HeaderContentTypeJSON(),            // Body has JSON content-type header
+//		vhttp.HeaderAuthorizationMatchesBearer(), // "Authorization" header matches regex `^Bearer .+$`
+//		vhttp.URLPathIs("/users/all"),            // URL Path == "/users/all"
+//	)
 func ValidateRequest(req *http.Request, vs ...RequestValidator) error {
 	// Check that the request is not nil
 	if req == nil {
@@ -100,11 +108,33 @@ func ValidateRequest(req *http.Request, vs ...RequestValidator) error {
 	return nil
 }
 
+// ValidateRequestFF validates the request against the given validators
+// but fails fast.
+//
+// This is a version of the ValidateRequest function that stops at the
+// first validation error returned (if any).
+func ValidateRequestFF(req *http.Request, vs ...RequestValidator) error {
+	// Check that the request is not nil
+	if req == nil {
+		return fmt.Errorf("request is nil")
+	}
+
+	// Iterate through the request validators.
+	for _, v := range vs {
+		if err := v.ValidateRequest(req); err != nil {
+			return err
+		}
+	}
+
+	// Success!
+	return nil
+}
+
 // ValidateResponse validates the response against the given validators.
 func ValidateResponse(res *http.Response, vs ...ResponseValidator) error {
 	// Check that the response is not nil
 	if res == nil {
-		return fmt.Errorf("request is nil")
+		return fmt.Errorf("response is nil")
 	}
 
 	// Iterate through the response validators.
@@ -120,5 +150,27 @@ func ValidateResponse(res *http.Response, vs ...ResponseValidator) error {
 	if merr != nil {
 		return multierror.Flatten(merr)
 	}
+	return nil
+}
+
+// ValidateResponseFF validates the response against the given validators
+// but fails fast.
+//
+// This is a version of the ValidateResponse function that stops at the
+// first validation error returned (if any).
+func ValidateResponseFF(res *http.Response, vs ...ResponseValidator) error {
+	// Check that the response is not nil
+	if res == nil {
+		return fmt.Errorf("response is nil")
+	}
+
+	// Iterate through the response validators.
+	for _, v := range vs {
+		if err := v.ValidateResponse(res); err != nil {
+			return err
+		}
+	}
+
+	// Success!
 	return nil
 }

--- a/vhttp_test.go
+++ b/vhttp_test.go
@@ -1,7 +1,225 @@
 package vhttp_test
 
-import "testing"
+import (
+	"errors"
+	"net/http"
+	"testing"
 
-func TestValidateRequest(t *testing.T) {}
+	"github.com/a-poor/vhttp"
+)
 
-func TestValidateResponse(t *testing.T) {}
+// t.Run("", func(t *testing.T) {})
+
+func TestValidateRequest(t *testing.T) {
+	t.Run("non-nil-request", func(t *testing.T) {
+		err := vhttp.ValidateRequest(&http.Request{})
+		if err != nil {
+			t.Errorf("Unexpected error validating non-nil request with no validators: %s", err)
+		}
+	})
+	t.Run("nil-request", func(t *testing.T) {
+		err := vhttp.ValidateRequest(nil)
+		if err == nil {
+			t.Error("Expected an error to be returned when validating a nil request")
+		}
+	})
+	t.Run("doesnt-fail-fast", func(t *testing.T) {
+		// Create a request
+		req := &http.Request{}
+
+		// Create three validator functions and corresponding flags
+		// to track if they've run.
+		//
+		// The second function will return an error.
+		//
+		// Since this function doesn't fail fast, all three should run.
+		runA, runB, runC := false, false, false
+		fa := vhttp.RequestFunc(func(req *http.Request) error {
+			runA = true
+			return nil
+		})
+		fb := vhttp.RequestFunc(func(req *http.Request) error {
+			runB = true
+			return errors.New("an error!")
+		})
+		fc := vhttp.RequestFunc(func(req *http.Request) error {
+			runC = true
+			return nil
+		})
+
+		// Validate
+		err := vhttp.ValidateRequest(req, fa, fb, fc)
+
+		// An error should have been returned
+		if err == nil {
+			t.Error("expected an error to be returned")
+		}
+
+		// Check which functions have run
+		if !runA || !runB || !runC {
+			t.Errorf("Expected all three functions to have run. RunA=%t, RunB=%t, RunC=%t", runA, runB, runC)
+		}
+	})
+}
+
+func TestValidateRequestFF(t *testing.T) {
+	t.Run("non-nil-request", func(t *testing.T) {
+		err := vhttp.ValidateRequestFF(&http.Request{})
+		if err != nil {
+			t.Errorf("Unexpected error validating non-nil request with no validators: %s", err)
+		}
+	})
+	t.Run("nil-request", func(t *testing.T) {
+		err := vhttp.ValidateRequestFF(nil)
+		if err == nil {
+			t.Error("Expected an error to be returned when validating a nil request")
+		}
+	})
+	t.Run("fails-fast", func(t *testing.T) {
+		// Create a request
+		req := &http.Request{}
+
+		// Create three validator functions and corresponding flags
+		// to track if they've run.
+		//
+		// The second function will return an error.
+		//
+		// Since this function fails fast, only the first two should run.
+		runA, runB, runC := false, false, false
+		fa := vhttp.RequestFunc(func(req *http.Request) error {
+			runA = true
+			return nil
+		})
+		fb := vhttp.RequestFunc(func(req *http.Request) error {
+			runB = true
+			return errors.New("an error!")
+		})
+		fc := vhttp.RequestFunc(func(req *http.Request) error {
+			runC = true
+			return nil
+		})
+
+		// Validate
+		err := vhttp.ValidateRequestFF(req, fa, fb, fc)
+
+		// An error should have been returned
+		if err == nil {
+			t.Error("expected an error to be returned")
+		}
+
+		// Check which functions have run
+		if !runA || !runB {
+			t.Errorf("Expected the first two functions to have run. RunA=%t, RunB=%t", runA, runB)
+		}
+		if runC {
+			t.Error("Expected the third function to have been skipped.")
+		}
+	})
+}
+
+func TestValidateResponse(t *testing.T) {
+	t.Run("non-nil-response", func(t *testing.T) {
+		err := vhttp.ValidateResponse(&http.Response{})
+		if err != nil {
+			t.Errorf("Unexpected error validating non-nil request with no validators: %s", err)
+		}
+	})
+	t.Run("nil-response", func(t *testing.T) {
+		err := vhttp.ValidateResponse(nil)
+		if err == nil {
+			t.Error("Expected an error to be returned when validating a nil response")
+		}
+	})
+	t.Run("doesnt-fail-fast", func(t *testing.T) {
+		// Create a response
+		req := &http.Response{}
+
+		// Create three validator functions and corresponding flags
+		// to track if they've run.
+		//
+		// The second function will return an error.
+		//
+		// Since this function doesn't fail fast, all three should run.
+		runA, runB, runC := false, false, false
+		fa := vhttp.ResponseFunc(func(req *http.Response) error {
+			runA = true
+			return nil
+		})
+		fb := vhttp.ResponseFunc(func(req *http.Response) error {
+			runB = true
+			return errors.New("an error!")
+		})
+		fc := vhttp.ResponseFunc(func(req *http.Response) error {
+			runC = true
+			return nil
+		})
+
+		// Validate
+		err := vhttp.ValidateResponse(req, fa, fb, fc)
+
+		// An error should have been returned
+		if err == nil {
+			t.Error("expected an error to be returned")
+		}
+
+		// Check which functions have run
+		if !runA || !runB || !runC {
+			t.Errorf("Expected all three functions to have run. RunA=%t, RunB=%t, RunC=%t", runA, runB, runC)
+		}
+	})
+}
+
+func TestValidateResponseFF(t *testing.T) {
+	t.Run("non-nil-response", func(t *testing.T) {
+		err := vhttp.ValidateResponseFF(&http.Response{})
+		if err != nil {
+			t.Errorf("Unexpected error validating non-nil request with no validators: %s", err)
+		}
+	})
+	t.Run("nil-response", func(t *testing.T) {
+		err := vhttp.ValidateResponseFF(nil)
+		if err == nil {
+			t.Error("Expected an error to be returned when validating a nil response")
+		}
+	})
+	t.Run("fails-fast", func(t *testing.T) {
+		// Create a response
+		req := &http.Response{}
+
+		// Create three validator functions and corresponding flags
+		// to track if they've run.
+		//
+		// The second function will return an error.
+		//
+		// Since this function fails fast, only the first two should run.
+		runA, runB, runC := false, false, false
+		fa := vhttp.ResponseFunc(func(req *http.Response) error {
+			runA = true
+			return nil
+		})
+		fb := vhttp.ResponseFunc(func(req *http.Response) error {
+			runB = true
+			return errors.New("an error!")
+		})
+		fc := vhttp.ResponseFunc(func(req *http.Response) error {
+			runC = true
+			return nil
+		})
+
+		// Validate
+		err := vhttp.ValidateResponseFF(req, fa, fb, fc)
+
+		// An error should have been returned
+		if err == nil {
+			t.Error("expected an error to be returned")
+		}
+
+		// Check which functions have run
+		if !runA || !runB {
+			t.Errorf("Expected the first two functions to have run. RunA=%t, RunB=%t", runA, runB)
+		}
+		if runC {
+			t.Error("Expected the third function to have been skipped.")
+		}
+	})
+}


### PR DESCRIPTION
* Add Fail-Fast validator functions
* Fixing removing unused param in `vhttp.HasHeaderContentType` (had a _content-type_ parameter when it shouldn't have)
* Update unit tests (and added errors – `errors.New("not implemented")` – to unimplemented unit tests)
